### PR TITLE
Flow Cred to SourceCred as a dependency

### DIFF
--- a/config/dependencies.json
+++ b/config/dependencies.json
@@ -1,0 +1,12 @@
+[
+    {
+        "autoActivateOnIdentityCreation": true,
+        "name": "sourcecred",
+        "periods": [
+            {
+                "startTime": "2020-09-20",
+                "weight": 0.05
+            }
+        ]
+    }
+]


### PR DESCRIPTION
This adds a dependencies.json file, with SourceCred as a dependency, set
to auto-activate (i.e. receive PRTCL) and with a weight of 0.05.

I set the start date for yesterday, b.c. it seems like that's when SC
started being used to distribute PRTCL.

If merged, this will result in SourceCred having about 4.8% of the Cred in
the instance. Let me know if this doesn't feel fair to you. Thanks!